### PR TITLE
fix: add npm package source metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,13 @@
   "type": "module",
   "version": "0.2.4",
   "homepage": "https://github.com/pinax-network/pinax-mcp",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pinax-network/pinax-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/pinax-network/pinax-mcp/issues"
+  },
   "license": "Apache-2.0",
   "keywords": ["mcp", "stdio", "sse", "ai", "llm", "blockchain"],
   "bin": {


### PR DESCRIPTION
## Summary
- add standard npm `repository` and `bugs` metadata for `@pinax/mcp`
- keep the existing homepage and point registry tooling to this public source repository and issue tracker

## Reproduction
The current published npm metadata exposes `homepage`, but omits standard source/issues fields:

```sh
npm view @pinax/mcp@0.2.4 name version homepage repository bugs --json
```

Observed: no `repository` or `bugs` entries are returned.

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json valid')"`
- `npm pack --dry-run --json`

Note: this project uses Bun for its normal `lint`/`test` scripts, and Bun is not installed in my local Windows environment, so I limited verification to JSON/package metadata validation for this metadata-only change.
