### PR TITLE
Migrate to mcp.pinax.network and drop SQL/SSE support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-ACCESS_TOKEN=<https://thegraph.market JWT Access Token>
-SSE_URL=https://token-api.mcp.thegraph.com/sse
+ACCESS_TOKEN=<JWT Access Token from https://app.pinax.network/keys>
+REMOTE_URL=https://mcp.pinax.network

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![license](https://img.shields.io/github/license/pinax-network/pinax-mcp)
 
-> An MCP Client for connecting to MCP Server‐compatible services at https://thegraph.market.
+> An MCP Client for connecting to MCP Server‐compatible services at https://app.pinax.network.
 
 ## Usage
 
@@ -14,36 +14,32 @@ A bridge client for connecting Claude Desktop and other MCP-compatible clients t
 Options:
   -V, --version              output the version number
   --remote-url <string>      Remote MCP server URL (env: REMOTE_URL)
-  --sse-url <string>         [DEPRECATED] Use --remote-url instead (env: SSE_URL)
   --access-token <string>    JWT Access Token (env: ACCESS_TOKEN)
   -v, --verbose <boolean>    Enable verbose logging (choices: "true", "false", default: false, env: VERBOSE)
   -h, --help                 display help for command
 ```
 
-Documentation: https://thegraph.com/docs/en/ai-suite/token-api-mcp/introduction/
+Documentation: https://app.pinax.network/docs/guides/mcp
 
 ## Endpoints
 
-This MCP allows LLMSs to access data provided by [The Graph Token API](https://thegraph.com/docs/en/token-api/quick-start/).
+This MCP allows LLMs to access data provided by the [Pinax Token API](https://app.pinax.network/docs).
 
-Two MCPs are available: 
-- Use `https://token-api.mcp.thegraph.com/mcp` for the REST-based MCP (all tiers)
-- Use `https://token-api.mcp.thegraph.com/sse` for the SQL-based MCP (paid tiers)
+- Use `https://mcp.pinax.network` for the MCP server (Streamable HTTP)
 
 ## Authentication
 
-1. Create a free account at https://thegraph.market using your GitHub credentials
-2. Go to **Dashboard**
-3. Click **Create New Key**
-4. Click **Generate Access Token**
+1. Sign in at https://app.pinax.network
+2. Go to [**Keys**](https://app.pinax.network/keys)
+3. Copy your project key and generate a JWT Access Token
 
 ## Configuration
 
 ### Environment Variables (`.env`)
 
 ```env
-ACCESS_TOKEN=<your-jwt-token-from-thegraph.market>
-REMOTE_URL=https://token-api.mcp.thegraph.com/mcp
+ACCESS_TOKEN=<your-jwt-token-from-app.pinax.network>
+REMOTE_URL=https://mcp.pinax.network
 ```
 
 ### Claude Desktop Configuration
@@ -64,7 +60,7 @@ Add to your Claude Desktop config file:
       "args": [
         "@pinax/mcp",
         "--remote-url",
-        "https://token-api.mcp.thegraph.com/mcp",
+        "https://mcp.pinax.network",
         "--access-token",
         "YOUR_ACCESS_TOKEN_HERE"
       ]
@@ -82,7 +78,7 @@ Or using environment variables:
       "command": "npx",
       "args": ["@pinax/mcp"],
       "env": {
-        "REMOTE_URL": "https://token-api.mcp.thegraph.com/mcp",
+        "REMOTE_URL": "https://mcp.pinax.network",
         "ACCESS_TOKEN": "YOUR_ACCESS_TOKEN_HERE"
       }
     }
@@ -138,7 +134,7 @@ npx @pinax/mcp --remote-url https://example.com/mcp --access-token YOUR_TOKEN -v
 - Check that the `REMOTE_URL` is correct and accessible
 
 **Authentication Failed:**
-- Generate a new access token at https://thegraph.market
+- Generate a new access token at https://app.pinax.network/keys
 - Ensure the token hasn't expired
 
 **Server Disconnected:**
@@ -174,8 +170,8 @@ bun run build
 ```
 ┌─────────────────┐          ┌──────────────┐          ┌─────────────────┐
 │  Claude Desktop │◄──stdio─►│  MCP Bridge  │◄──HTTP──►│  Remote MCP     │
-│  (or other      │          │   Client     │    or    │  Server         │
-│   MCP client)   │          └──────────────┘◄──SSE───►└─────────────────┘
+│  (or other      │          │   Client     │          │  Server         │
+│   MCP client)   │          └──────────────┘          └─────────────────┘
 └─────────────────┘
 ```
 

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type {
@@ -30,11 +29,6 @@ const opts = program
 		),
 	)
 	.addOption(
-		new Option("--sse-url <string>", "[DEPRECATED] Use --remote-url instead")
-			.env("SSE_URL")
-			.hideHelp(),
-	)
-	.addOption(
 		new Option("--access-token <string>", "JWT Access Token").env(
 			"ACCESS_TOKEN",
 		),
@@ -49,15 +43,8 @@ const opts = program
 	.opts();
 
 const ACCESS_TOKEN = opts.accessToken;
-const REMOTE_URL = opts.remoteUrl || opts.sseUrl;
+const REMOTE_URL = opts.remoteUrl;
 const AUTH_HEADER_VALUE = `Bearer ${ACCESS_TOKEN}`;
-
-// Show deprecation warning
-if (opts.sseUrl && !opts.remoteUrl) {
-	console.error(
-		"Warning: --sse-url is deprecated. Please use --remote-url instead.",
-	);
-}
 
 // Validation
 if (!REMOTE_URL) {
@@ -73,18 +60,6 @@ if (!ACCESS_TOKEN) {
 	);
 	process.exit(1);
 }
-
-// Auto-detect transport type based on URL ending
-const detectTransportType = (url: string): "sse" | "streamable-http" => {
-	if (url.endsWith("/sse") || url.endsWith("/sql")) {
-		return "sse";
-	} else {
-		// Default to Streamable HTTP
-		return "streamable-http";
-	}
-};
-
-const transportType = detectTransportType(REMOTE_URL);
 
 // Logger (stderr for logging, stdout for MCP protocol)
 const logger = { info: opts.verbose ? console.error : () => {} };
@@ -103,21 +78,13 @@ const fetchWithAuth = (url: string | URL, init?: RequestInit) => {
 	return fetch(url.toString(), { ...init, headers });
 };
 
-// Create transport based on detected type
+// Create Streamable HTTP transport
 const createTransport = () => {
-	if (transportType === "streamable-http") {
-		logger.info("Using Streamable HTTP transport");
-		return new StreamableHTTPClientTransport(new URL(REMOTE_URL), {
-			requestInit: { headers: { [AUTH_HEADER_NAME]: AUTH_HEADER_VALUE } },
-			fetch: fetchWithAuth,
-		});
-	} else {
-		logger.info("Using SSE transport");
-		return new SSEClientTransport(new URL(REMOTE_URL), {
-			eventSourceInit: { fetch: fetchWithAuth },
-			requestInit: { headers: { [AUTH_HEADER_NAME]: AUTH_HEADER_VALUE } },
-		});
-	}
+	logger.info("Using Streamable HTTP transport");
+	return new StreamableHTTPClientTransport(new URL(REMOTE_URL), {
+		requestInit: { headers: { [AUTH_HEADER_NAME]: AUTH_HEADER_VALUE } },
+		fetch: fetchWithAuth,
+	});
 };
 
 // Main
@@ -146,10 +113,9 @@ const createTransport = () => {
 		}
 	};
 
-	remoteTransport.onerror = (err) =>
-		logger.info(`${transportType} error:`, err);
+	remoteTransport.onerror = (err) => logger.info("Transport error:", err);
 	remoteTransport.onclose = () => {
-		logger.info(`${transportType} connection closed`);
+		logger.info("Transport connection closed");
 		process.exit(1);
 	};
 
@@ -192,9 +158,9 @@ const createTransport = () => {
 		}
 	};
 
-	logger.info(`Connecting to remote ${transportType} at ${REMOTE_URL}`);
+	logger.info(`Connecting to remote MCP server at ${REMOTE_URL}`);
 	await remoteClient.connect(remoteTransport);
 	await stdioTransport.start();
-	logger.info(`${transportType} successfully connected!`);
-	logger.info(`Bridge running: Stdio ↔ ${transportType}`);
+	logger.info("Remote MCP server successfully connected!");
+	logger.info("Bridge running: Stdio ↔ Streamable HTTP");
 })();

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@pinax/mcp",
-  "description": "An MCP Client for connecting to MCP Server‐compatible services at https://thegraph.market.",
+  "description": "An MCP Client for connecting to MCP Server‐compatible services at https://app.pinax.network.",
   "private": "false",
   "type": "module",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "homepage": "https://github.com/pinax-network/pinax-mcp",
   "license": "Apache-2.0",
-  "keywords": ["mcp", "stdio", "sse", "ai", "llm", "blockchain"],
+  "keywords": ["mcp", "stdio", "ai", "llm", "blockchain"],
   "bin": {
     "pinax-mcp": "dist/index.js"
   },


### PR DESCRIPTION
## Summary

Migrates `@pinax/mcp` off The Graph's endpoints onto Pinax's own MCP server, and drops the now-unsupported SQL (SSE) transport. The client is now a single-transport Streamable HTTP bridge.

## Endpoint & auth migration

| | Before | After |
|---|---|---|
| MCP endpoint | `https://token-api.mcp.thegraph.com/mcp` (REST) + `/sse` (SQL) | `https://mcp.pinax.network` (Streamable HTTP, served at root) |
| Account / docs | `thegraph.market`, `thegraph.com/docs/...` | `app.pinax.network` |
| Access token | `thegraph.market` dashboard | `app.pinax.network/keys` |

The new server serves MCP over Streamable HTTP at the **root** path — the old `/mcp`, `/sse`, and `/sql` paths return 404. Verified directly: a no-auth `initialize` against `https://mcp.pinax.network/` returns `serverInfo: { name: "Token API MCP" }`.

## Dropping SQL / SSE

SQL was the SSE-based endpoint (the paid-tier `/sse` MCP). Since it's no longer supported, the SSE transport is removed entirely rather than left dead:

- Removed the `--sse-url` / `SSE_URL` deprecated option and its deprecation warning. `REMOTE_URL` now comes solely from `--remote-url`.
- Removed `detectTransportType()` (the `/sse` + `/sql` URL-suffix sniffing) — `createTransport()` always returns a `StreamableHTTPClientTransport`.
- Removed the `SSEClientTransport` import and the SSE branch.
- Replaced dynamic `${transportType}` log strings with fixed wording.
- Dropped `"sse"` from `package.json` keywords.

## Docs

- README rewritten: tagline, docs link, endpoints section, auth steps, `.env` example, both Claude Desktop config snippets, troubleshooting, Usage help block, and the architecture diagram (removed the SSE leg).
- `.env.example`: `SSE_URL=.../sse` → `REMOTE_URL=https://mcp.pinax.network`.
- A companion MCP setup guide (`/docs/guides/mcp`) has been added in the `app-frontend` repo (separate PR), which the README's `Documentation:` link now points to.

## Versioning

Bumped **0.2.4 → 0.3.0**. Minor bump rather than patch because removing the `--sse-url` alias and SSE transport is a breaking behavior change for anyone relying on them.

## Test plan

- [x] Verified `https://mcp.pinax.network` responds to MCP `initialize` over Streamable HTTP at root; old `/mcp`, `/sse`, `/sql` paths 404.
- [x] Confirmed no remaining `thegraph` / `token-api.mcp` / `sse` / `sql` references in source.
- [ ] Smoke test against a live client (Claude Desktop) with a real JWT from `app.pinax.network/keys`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)